### PR TITLE
Update SparkFun_VL53L1X.cpp

### DIFF
--- a/src/SparkFun_VL53L1X.cpp
+++ b/src/SparkFun_VL53L1X.cpp
@@ -270,7 +270,7 @@ uint16_t SFEVL53L1X::getDistanceThresholdHigh()
 
 void SFEVL53L1X::setROI(uint16_t x, uint16_t y)
 {
-	_device->VL53L1X_SetROI(x, x);
+	_device->VL53L1X_SetROI(x, y);
 }
 
 uint16_t SFEVL53L1X::getROIX()


### PR DESCRIPTION
I think there is a typo.
To set ROI-X and ROI-Y independantly, x and y should be passed to VL53L1X_SetROI()