### PR TITLE
Fix casting of registeraddress

### DIFF
--- a/src/vl53l1x_class.cpp
+++ b/src/vl53l1x_class.cpp
@@ -1024,8 +1024,8 @@ VL53L1X_ERROR VL53L1X::VL53L1_I2CWrite(uint8_t DeviceAddr, uint16_t RegisterAddr
    Serial.println(RegisterAddr);
 #endif
    uint8_t buffer[2];
-   buffer[0]=(uint8_t) RegisterAddr>>8;
-   buffer[1]=(uint8_t) RegisterAddr&0xFF;
+   buffer[0]=RegisterAddr>>8;
+   buffer[1]=RegisterAddr&0xFF;
    dev_i2c->write(buffer, 2);
    for (int i = 0 ; i < NumByteToWrite ; i++)
      dev_i2c->write(pBuffer[i]);
@@ -1049,8 +1049,8 @@ VL53L1X_ERROR VL53L1X::VL53L1_I2CRead(uint8_t DeviceAddr, uint16_t RegisterAddr,
    Serial.println(RegisterAddr);
 #endif
    uint8_t buffer[2];
-   buffer[0]=(uint8_t) RegisterAddr>>8;
-   buffer[1]=(uint8_t) RegisterAddr&0xFF;
+   buffer[0]=RegisterAddr>>8;
+   buffer[1]=RegisterAddr&0xFF;
    dev_i2c->write(buffer, 2);
    status = dev_i2c->endTransmission(false);
 //Fix for some STM32 boards


### PR DESCRIPTION
(uint8_t) RegisterAddr>>8 is not correct. This casts the Registeraddress to a uint8_t and shifts it to the right by 8 bits. The cast can be removed as it is unnecessary or put parentheses around the shift like this:
(uint8_t) (RegisterAddr>>8)