### PR TITLE
Added One-Shot Ranging trigger

### DIFF
--- a/src/SparkFun_VL53L1X.cpp
+++ b/src/SparkFun_VL53L1X.cpp
@@ -133,6 +133,10 @@ void SFEVL53L1X::startRanging()
 	_device->VL53L1X_StartRanging();
 }
 
+void SFEVL53L1X::startOneshotRanging() {
+  	_device->VL53L1X_StartOneshotRanging();
+}
+
 void SFEVL53L1X::stopRanging()
 {
 	_device->VL53L1X_StopRanging();

--- a/src/SparkFun_VL53L1X.h
+++ b/src/SparkFun_VL53L1X.h
@@ -47,6 +47,7 @@ class SFEVL53L1X
 	void setInterruptPolarityLow(); //Set the polarity of an active interrupt to Low
 	uint8_t getInterruptPolarity(); //get the current interrupt polarity
 	void startRanging(); //Begins taking measurements
+	void startOneshotRanging();  // Start one-shot ranging
 	void stopRanging(); //Stops taking measurements
 	bool checkForDataReady(); //Checks the to see if data is ready
 	void setTimingBudgetInMs(uint16_t timingBudget); //Set the timing budget for a measurement

--- a/src/vl53l1x_class.cpp
+++ b/src/vl53l1x_class.cpp
@@ -223,8 +223,16 @@ VL53L1X_ERROR VL53L1X::VL53L1X_GetInterruptPolarity(uint8_t *pInterruptPolarity)
 VL53L1X_ERROR VL53L1X::VL53L1X_StartRanging()
 {
 	VL53L1X_ERROR status = 0;
-
+	// Consider: maybe also VL53L1_WrByte(Device, SYSTEM__INTERRUPT_CLEAR, 0x01); /* clear interrupt trigger */
 	status = VL53L1_WrByte(Device, SYSTEM__MODE_START, 0x40); /* Enable VL53L1X */
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X::VL53L1X_StartOneshotRanging()
+{
+	VL53L1X_ERROR status = 0;
+	VL53L1_WrByte(Device, SYSTEM__INTERRUPT_CLEAR, 0x01); /*  clear interrupt trigger */
+	status = VL53L1_WrByte(Device, SYSTEM__MODE_START, 0x10); /* Enable VL53L1X one-shot ranging */
 	return status;
 }
 

--- a/src/vl53l1x_class.h
+++ b/src/vl53l1x_class.h
@@ -305,6 +305,11 @@ class VL53L1X : public RangeSensor
 	VL53L1X_ERROR VL53L1X_StartRanging();
 
 	/**
+	 * @brief This function starts a one-shot ranging distance operation\n
+	 */
+	VL53L1X_ERROR VL53L1X_StartOneshotRanging();
+
+	/**
 	 * @brief This function stops the ranging.
 	 */
 	VL53L1X_ERROR VL53L1X_StopRanging();


### PR DESCRIPTION
I've been exploring sweeping the ROI around to get a "2d" lidar out of each VL53L1x and found that with continuous ranging (StartRanging/StopRanging), the sensor wasn't "taking" the updated ROI consistantly. 

I tried waiting for a reading to complete, then stopping the ranging operation in the gap between the timing budget and inter-measurement period, but this was really fragile and would frequently stop working and I'd get results from the wrong SPAD ROI, even though reading the SPAD ROI showed the correct number (which I might put in as another PR with some ROI setting improvements I'm working on).

I think it's just a problem in the internal sensor state machine, where calling stop doesn't take effect immediately, and the ROI settings applied when ranging is active don't work (the datasheet errata talks about how setting ROI when ranging is invalid, but doesn't elaborate).

With this method, I can 100% reliably set the ROI, trigger ranging, then get a single result in a loop, wheras before I had to start, get the results, and stop all spaced out by carefully tuned magic delay numbers.

I tried to match the existing code style in each file, but I'm open to suggestions.